### PR TITLE
New Intercom's API

### DIFF
--- a/lib/Intercom/Client/Event.php
+++ b/lib/Intercom/Client/Event.php
@@ -10,8 +10,6 @@ use Intercom\AbstractClient,
 
 class Event extends AbstractClient
 {
-    const INTERCOM_BASE_URL = 'https://api.intercom.io/events';
-
     /**
      * Create an Event
      *
@@ -23,6 +21,6 @@ class Event extends AbstractClient
      */
     public function create(EventObject $event)
     {
-        return $this->send(new Request('POST', self::INTERCOM_BASE_URL, [], $event->format()));
+        return $this->send(new Request('POST', self::INTERCOM_BASE_URL . '/events', [], $event->format()));
     }
 }

--- a/lib/Intercom/Exception/BulkException.php
+++ b/lib/Intercom/Exception/BulkException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Intercom\Exception;
+
+/**
+ * Exception related to a bulk
+ */
+class BulkException extends AbstractIntercomException
+{
+}

--- a/lib/Intercom/Object/User.php
+++ b/lib/Intercom/Object/User.php
@@ -20,7 +20,7 @@ class User implements FormatableInterface
     private $name;
     private $createdAt;
     private $lastSeenIp;
-    private $customData;
+    private $customAttributes;
     private $lastSeenUserAgent;
     private $lastRequestAt;
     private $unsubscribedFromEmails;
@@ -45,7 +45,7 @@ class User implements FormatableInterface
         $this->userId = $userId;
         $this->email = mb_strtolower($email, mb_detect_encoding($email));
         $this->createdAt = time();
-        $this->customData = [];
+        $this->customAttributes = [];
     }
 
     /**
@@ -59,14 +59,17 @@ class User implements FormatableInterface
             'name'                     => $this->name,
             'created_at'               => $this->createdAt,
             'last_seen_ip'             => $this->lastSeenIp,
-            'custom_data'              => $this->customData,
+            'custom_attributes'        => $this->customAttributes,
             'last_seen_user_agent'     => $this->lastSeenUserAgent,
             'last_request_at'          => $this->lastRequestAt,
             'unsubscribed_from_emails' => $this->unsubscribedFromEmails,
-            'location_data'            => $this->locationData,
-            'session_count'            => $this->sessionCount,
-            'social_profiles'          => $this->socialProfiles,
-            'last_impression_at'       => $this->lastImpressionAt,
+
+            // @todo Disable the following field temporarily
+
+            // 'location_data'            => $this->locationData,
+            // 'session_count'            => $this->sessionCount,
+            // 'social_profiles'          => $this->socialProfiles,
+            // 'last_impression_at'       => $this->lastImpressionAt,
         ];
     }
 
@@ -215,52 +218,52 @@ class User implements FormatableInterface
     }
 
     /**
-     * Set CustomData
+     * Set CustomAttributes
      *
-     * @param  array $customData
+     * @param  array $customAttributes
      *
      * @return $this
      */
-    public function setCustomData(array $customData)
+    public function setCustomAttributes(array $customAttributes)
     {
-        $this->customData = $customData;
+        $this->customAttributes = $customAttributes;
 
         return $this;
     }
 
     /**
-     * Get CustomData
+     * Get CustomAttributes
      *
      * @return array
      */
-    public function getCustomData($property = null)
+    public function getCustomAttributes($property = null)
     {
-        return null !== $property && isset($this->customData[$property]) ? $this->customData[$property] : $this->customData;
+        return null !== $property && isset($this->customAttributes[$property]) ? $this->customAttributes[$property] : $this->customAttributes;
     }
 
     /**
-     * Add a property in customData
+     * Add a property in customAttributes
      *
      * @param string $property
      * @param string $value
      */
-    public function addCustomData($property, $value)
+    public function addCustomAttributes($property, $value)
     {
-        $this->customData[$property] = $value;
+        $this->customAttributes[$property] = $value;
 
         return $this;
     }
 
     /**
-     * Has a gievn property in customData
+     * Has a gievn property in customAttributes
      *
      * @param  string  $property
      *
      * @return boolean
      */
-    public function hasCustomData($property)
+    public function hasCustomAttributes($property)
     {
-        return isset($this->customData[$property]);
+        return isset($this->customAttributes[$property]);
     }
 
     /**

--- a/lib/Intercom/Request/PaginatedResponse.php
+++ b/lib/Intercom/Request/PaginatedResponse.php
@@ -9,22 +9,22 @@ class PaginatedResponse
 {
     private $content;
     private $page;
-    private $nextPage;
+    private $nextUrl;
     private $totalPages;
     private $totalCount;
 
     /**
      * @param mixed   $content
      * @param integer $page
-     * @param integer $nextPage
+     * @param integer $nextUrl
      * @param integer $totalPages
      * @param integer $totalCount
      */
-    public function __construct($content, $page, $nextPage, $totalPages, $totalCount)
+    public function __construct($content, $page, $nextUrl, $totalPages, $totalCount)
     {
         $this->content = $content;
         $this->page = $page;
-        $this->nextPage = $nextPage;
+        $this->nextUrl = $nextUrl;
         $this->totalPages = $totalPages;
         $this->totalCount = $totalCount;
     }
@@ -50,13 +50,13 @@ class PaginatedResponse
     }
 
     /**
-     * Get nextPage
+     * Get nextUrl
      *
      * @return integer
      */
-    public function getNextPage()
+    public function getNextUrl()
     {
-        return $this->nextPage;
+        return $this->nextUrl;
     }
 
     /**
@@ -86,6 +86,16 @@ class PaginatedResponse
      */
     public function hasPageToBeFetch()
     {
-        return null !== $this->nextPage;
+        return $this->totalPages > $this->page;
+    }
+
+    /**
+     * Get the next page
+     *
+     * @return integer
+     */
+    public function getNextPage()
+    {
+        return $this->totalPages > $this->page ? $this->page + 1 : null;
     }
 }

--- a/lib/Intercom/Request/Search/UserSearch.php
+++ b/lib/Intercom/Request/Search/UserSearch.php
@@ -2,7 +2,8 @@
 
 namespace Intercom\Request\Search;
 
-use \InvalidArgumentException;
+use \InvalidArgumentException,
+    \LengthException;
 
 use Intercom\Request\FormatableInterface;
 
@@ -21,20 +22,22 @@ class UserSearch implements FormatableInterface
     private $order;
 
     /**
-     * @param integer  $page     the app id for the application’s inbox you wish to access
-     * @param integer  $perPage  Users per page, max value of 500
-     * @param interger $tagId    query for users that are tagged with a specific tag.
-     * @param string   $tagName  query for users that are tagged with a specific tag.
-     * @param string   $sort     sort the query for users based on a field. Accepted values - created_at.
-     * @param string   $order    sorts the results in ascending or descending order. Accepted values - asc, desc.
+     * @param integer  $page      the app id for the application’s inbox you wish to access
+     * @param integer  $perPage   Users per page, max value of 500
+     * @param string   $order     sorts the results in ascending or descending order. Accepted values - asc, desc.
+     * @param interger $tagId     The id of the tag to filter by
+     * @param integer  $segmentId The id of the segment to filter by
      */
-    public function __construct($page = 1, $perPage = 100, $tagId = null, $tagName = null, $sort = 'created_at', $order = 'asc')
+    public function __construct($page = 1, $perPage = 50, $order = 'asc', $tagId = null, $segmentId = null)
     {
+        if (null !== $tagId && null !== $segmentId) {
+            throw new InvalidArgumentException("You can not combine tag and segment in the same request");
+        }
+
         $this->setPage($page);
         $this->setPerPage($perPage);
         $this->setTagId($tagId);
-        $this->setTagName($tagName);
-        $this->setSort($sort);
+        $this->setSegmentId($segmentId);
         $this->setOrder($order);
     }
 
@@ -44,12 +47,11 @@ class UserSearch implements FormatableInterface
     public function format()
     {
         return [
-            'page'     => $this->page,
-            'per_page' => $this->perPage,
-            'tag_id'   => $this->tagId,
-            'tag_name' => $this->tagName,
-            'sort'     => $this->sort,
-            'order'    => $this->order,
+            'page'       => $this->page,
+            'per_page'   => $this->perPage,
+            'tag_id'     => $this->tagId,
+            'segment_id' => $this->segmentId,
+            'order'      => $this->order,
         ];
     }
 
@@ -82,6 +84,10 @@ class UserSearch implements FormatableInterface
      */
     public function setPerPage($perPage)
     {
+        if (50 < $perPage) {
+            throw new LengthException(sprintf("perPage must be minus than 50, %d given.", $perPage));
+        }
+
         $this->perPage = $perPage;
 
         return $this;
@@ -120,51 +126,27 @@ class UserSearch implements FormatableInterface
     }
 
     /**
-     * Set tag name
+     * Set SegmentId
      *
-     * @param string $tagName
+     * @param  integer $segmentId
+     *
+     * @return $this
      */
-    public function setTagName($tagName)
+    public function setSegmentId($segmentId)
     {
-        $this->tagName = $tagName;
+        $this->segmentId = $segmentId;
 
         return $this;
     }
 
     /**
-     * Get tag name
+     * Get SegmentId
      *
-     * @return string
+     * @return integer
      */
-    public function getTagName()
+    public function getSegmentId()
     {
-        return $this->tagName;
-    }
-
-    /**
-     * Set sort
-     *
-     * @param string $sort Only created_at for the moment
-     */
-    public function setSort($sort)
-    {
-        if (!in_array($sort, ['created_at'])) {
-            throw new InvalidArgumentException('sort must belong a correct field list. See the API doc.');
-        }
-
-        $this->sort = $sort;
-
-        return $this;
-    }
-
-    /**
-     * Get sort
-     *
-     * @return string
-     */
-    public function getSort()
-    {
-        return $this->sort;
+        return $this->segmentId;
     }
 
     /**

--- a/lib/Intercom/Request/Search/UserSearch.php
+++ b/lib/Intercom/Request/Search/UserSearch.php
@@ -31,7 +31,7 @@ class UserSearch implements FormatableInterface
     public function __construct($page = 1, $perPage = 50, $order = 'asc', $tagId = null, $segmentId = null)
     {
         if (null !== $tagId && null !== $segmentId) {
-            throw new InvalidArgumentException("You can not combine tag and segment in the same request");
+            throw new InvalidArgumentException("You can not combine tag and segment in the same request.");
         }
 
         $this->setPage($page);

--- a/tests/Intercom/Tests/Client/EventTest.php
+++ b/tests/Intercom/Tests/Client/EventTest.php
@@ -37,10 +37,10 @@ class EventTest extends PHPUnit_Framework_TestCase
             ->method('createRequest')
             ->with(
                 'POST',
-                EventClient::INTERCOM_BASE_URL,
+                EventClient::INTERCOM_BASE_URL . '/events',
                 [
-                    'headers' => ['Content-Type' => 'application\json'],
-                    'body'    => $event->format(),
+                    'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
+                    'json'    => $event->format(),
                     'query'   => [],
                     'auth'    => [$this->appId, $this->apiKey]
                 ]

--- a/tests/Intercom/Tests/Client/UserTest.php
+++ b/tests/Intercom/Tests/Client/UserTest.php
@@ -96,10 +96,9 @@ class UserTest extends PHPUnit_Framework_TestCase
             ->method('createRequest')
             ->with(
                 'GET',
-                UserClient::INTERCOM_BASE_URL,
+                UserClient::INTERCOM_BASE_URL. '/users',
                 [
-                    'headers' => ['Content-Type' => 'application\json'],
-                    'body'    => [],
+                    'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
                     'query'   => ['user_id' => 1],
                     'auth'    => [$this->appId, $this->apiKey]
                 ]
@@ -132,10 +131,9 @@ class UserTest extends PHPUnit_Framework_TestCase
             ->method('createRequest')
             ->with(
                 'GET',
-                UserClient::INTERCOM_BASE_URL,
+                UserClient::INTERCOM_BASE_URL . '/users',
                 [
-                    'headers' => ['Content-Type' => 'application\json'],
-                    'body'    => [],
+                    'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
                     'query'   => ['user_id' => 7902],
                     'auth'    => [$this->appId, $this->apiKey]
                 ]
@@ -186,10 +184,9 @@ class UserTest extends PHPUnit_Framework_TestCase
             ->method('createRequest')
             ->with(
                 'GET',
-                UserClient::INTERCOM_BASE_URL,
+                UserClient::INTERCOM_BASE_URL . '/users',
                 [
-                    'headers' => ['Content-Type' => 'application\json'],
-                    'body'    => [],
+                    'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
                     'query'   => ['user_id' => 2],
                     'auth'    => [$this->appId, $this->apiKey],
                 ]
@@ -213,13 +210,15 @@ class UserTest extends PHPUnit_Framework_TestCase
         $clientRequest = $this->getMock('GuzzleHttp\Message\RequestInterface');
 
         $apiResponseData = [
-            'users'       => [
+            'users' => [
                 $this->user,
                 $this->user,
             ],
-            'page'        => 1,
-            'next_page'   => 2,
-            'total_pages' => 10,
+            'pages' => [
+                'page'        => 1,
+                'next'        => 2,
+                'total_pages' => 10,
+            ],
             'total_count' => 100,
         ];
 
@@ -235,10 +234,9 @@ class UserTest extends PHPUnit_Framework_TestCase
             ->method('createRequest')
             ->with(
                 'GET',
-                UserClient::INTERCOM_BASE_URL,
+                UserClient::INTERCOM_BASE_URL . '/users',
                 [
-                    'headers' => ['Content-Type' => 'application\json'],
-                    'body'    => [],
+                    'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
                     'query'   => $search->format(),
                     'auth'    => [$this->appId, $this->apiKey]
                 ]
@@ -265,7 +263,7 @@ class UserTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::create()
      */
-    public function testCreate()
+    public function testCreateOrUpdate()
     {
         $user = new User(1);
 
@@ -283,10 +281,10 @@ class UserTest extends PHPUnit_Framework_TestCase
             ->method('createRequest')
             ->with(
                 'POST',
-                UserClient::INTERCOM_BASE_URL,
+                UserClient::INTERCOM_BASE_URL . '/users',
                 [
-                    'headers' => ['Content-Type' => 'application\json'],
-                    'body'    => $user->format(),
+                    'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
+                    'json'    => $user->format(),
                     'query'   => [],
                     'auth'    => [$this->appId, $this->apiKey]
                 ]
@@ -297,45 +295,7 @@ class UserTest extends PHPUnit_Framework_TestCase
             ->with($clientRequest)
             ->will(self::returnValue($response));
 
-        (new UserClient($this->appId, $this->apiKey, $client))->create($user);
-    }
-
-    /**
-     * @covers ::update()
-     */
-    public function testUpdate()
-    {
-        $user = new User(1);
-
-        $clientRequest = $this->getMock('GuzzleHttp\Message\RequestInterface');
-
-        $response = $this->getMock('GuzzleHttp\Message\ResponseInterface');
-        $response->expects(self::once())
-            ->method('json')
-            ->will(self::returnValue($this->user));
-
-        $client = $this->getMockBuilder('GuzzleHttp\ClientInterface')
-                        ->disableOriginalConstructor()
-                        ->getMock();
-        $client->expects(self::once())
-            ->method('createRequest')
-            ->with(
-                'PUT',
-                UserClient::INTERCOM_BASE_URL,
-                [
-                    'headers' => ['Content-Type' => 'application\json'],
-                    'body'    => $user->format(),
-                    'query'   => [],
-                    'auth'    => [$this->appId, $this->apiKey]
-                ]
-            )
-            ->will(self::returnValue($clientRequest));
-        $client->expects(self::once())
-            ->method('send')
-            ->with($clientRequest)
-            ->will(self::returnValue($response));
-
-        (new UserClient($this->appId, $this->apiKey, $client))->update($user);
+        (new UserClient($this->appId, $this->apiKey, $client))->createOrUpdate($user);
     }
 
     /**
@@ -359,10 +319,10 @@ class UserTest extends PHPUnit_Framework_TestCase
             ->method('createRequest')
             ->with(
                 'DELETE',
-                UserClient::INTERCOM_BASE_URL,
+                UserClient::INTERCOM_BASE_URL . '/users',
                 [
-                    'headers' => ['Content-Type' => 'application\json'],
-                    'body'    => $user->format(),
+                    'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
+                    'json'    => $user->format(),
                     'query'   => [],
                     'auth'    => [$this->appId, $this->apiKey]
                 ]

--- a/tests/Intercom/Tests/Object/UserTest.php
+++ b/tests/Intercom/Tests/Object/UserTest.php
@@ -8,17 +8,17 @@ use Intercom\Object\User;
 
 class UserTest extends PHPUnit_Framework_TestCase
 {
-    public function testAddCustomData()
+    public function testAddCustomAttributes()
     {
         $user = new User(1, 'FréDériC@bar.fr');
-        $user->addCustomData('foo', 'bar');
+        $user->addCustomAttributes('foo', 'bar');
 
-        $this->assertEquals('bar', $user->getCustomData('foo'));
-        $this->assertEquals(['foo' => 'bar'], $user->getCustomData());
-        $this->assertEquals(['foo' => 'bar'], $user->getCustomData('zzz'));
+        $this->assertEquals('bar', $user->getCustomAttributes('foo'));
+        $this->assertEquals(['foo' => 'bar'], $user->getCustomAttributes());
+        $this->assertEquals(['foo' => 'bar'], $user->getCustomAttributes('zzz'));
         $this->assertEquals('frédéric@bar.fr', $user->getEmail());
 
-        $this->assertTrue($user->hasCustomData('foo'));
-        $this->assertFalse($user->hasCustomData('zzz'));
+        $this->assertTrue($user->hasCustomAttributes('foo'));
+        $this->assertFalse($user->hasCustomAttributes('zzz'));
     }
 }

--- a/tests/Intercom/Tests/Request/Search/UserSearchTest.php
+++ b/tests/Intercom/Tests/Request/Search/UserSearchTest.php
@@ -11,20 +11,29 @@ class UserSearchTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider getSearchParameters
      */
-    public function testCreateASearchWithWrongParameters($page, $perPage, $tagId, $tagName, $sort, $order, $expectedMessage)
+    public function testCreateASearchWithWrongParameters($page, $perPage, $order, $tagId, $segmentId, $expectedMessage)
     {
         $this->setExpectedException(
             'InvalidArgumentException', $expectedMessage
         );
 
-        new UserSearch($page, $perPage, $tagId, $tagName, $sort, $order);
+        new UserSearch($page, $perPage, $order, $tagId, $segmentId);
     }
 
     public function getSearchParameters()
     {
         return [
-            [1, 100, 1, 'foo', 'foo', 'asc', 'sort must belong a correct field list. See the API doc.'],
-            [1, 100, 1, 'foo', 'created_at', 'foo', 'order must belong a correct type list. See the API doc.'],
+            [1, 50, 'foo', null, null, 'order must belong a correct type list. See the API doc.'],
+            [1, 50, 'asc', 1, 1, 'You can not combine tag and segment in the same request.'],
         ];
+    }
+
+    /**
+     * @expectedException LengthException
+     * @expectedExceptionMessage perPage must be minus than 50, 100 given.
+     */
+    public function testCreateASearchWithWrongPerPage()
+    {
+        new UserSearch(1, 100);
     }
 }


### PR DESCRIPTION
Update Intercom-php with the newest API of Intercom

http://doc.intercom.io/api/
### Changelog
- The new common endpoint used by `User` and `Event` clients is `https://api.intercom.io`
- For **POST**, **PUT**, **PATCH** and **DELETE** request, body is sent in `json` parameter instead of `body`
- Merge `Client\User::create()` and `Client\User::update()` into `Client\User::createOrUpdate()`
- `Client\User::createOrUpdate()` handle bulk if an array is given.
- `Object\User::customData` become `Object\User::customAttributes`
- `PaginatedResponse::nextPage` become `PaginatedResponse::nextUrl`.
- `UserSearch::perPage` default is now 50 instead of 100
- `UserSearch::tagName` removed
- `UserSearch::sort` removed 
- `UserSearch::segmentId` added
